### PR TITLE
Fixing metadata table height to 500px

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -252,7 +252,7 @@ def table_from_df(df: pd.DataFrame, table_name: str):
              columns=columns,
              multiple=True, # Hack for not navigating alway when doing 1 click on table
              downloadable  = True, 
-             height='100%')
+             height='500px')
     return table
 
 # create the benchmark df and the results csv 


### PR DESCRIPTION
The metadata table was not showing up in some systems, and this is resolved if we set the height manually.  We still might want to look into making the table row height slightly (1-2 rows) bigger for better visibility via [this setting](https://github.com/h2oai/wave-amlb/blob/main/src/config.py#L37-L43).